### PR TITLE
src/client/Dockerfile: Use "cp -R" over "mv"

### DIFF
--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 
 RUN mkdir -p /var/www/html
 
-RUN mv build/* /var/www/html
+RUN cp -R build/* /var/www/html
 
 WORKDIR /
 


### PR DESCRIPTION
The previous "mv build/* html" had subdirectories in it, namely build/static/{js,css}, which gets moved to the target in the first run. However, the second "mv" is trying to move a non-empty directory to a target that has a non-empty directory with the same name, and it fails. The exquisite part is that there is no failure log in the GitHub actions runner job [0], but we're changing to a more robust "cp -r" anyway.

Looking at the modification timestamp of the files in /var/www/html inside the prod nginx container confirms it: they were last modified when the server was deployed.

[0]: https://github.com/Laisses/crafty-inspire/actions/runs/4759222437/jobs/8458255361